### PR TITLE
fix browserify executable path

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "watchify -vd -p browserify-hmr -t vueify -e src/main.js -o build/build.js & http-server -c 1 -a localhost",
-    "build": "cross-env NODE_ENV=production ./node_modules/watchify/node_modules/.bin/browserify -t vueify -e src/main.js | uglifyjs -c warnings=false -m > build/build.js"
+    "build": "cross-env NODE_ENV=production ./node_modules/.bin/browserify -t vueify -e src/main.js | uglifyjs -c warnings=false -m > build/build.js"
   },
   "author": "Evan You",
   "license": "MIT",


### PR DESCRIPTION
I'm seeing the following issue when running `npm run build` 

    Gertrude:vueify-example tanner$ npm run build
    
    > vueify-example@1.0.0 build /Users/tanner/Desktop/vueify-example
    > cross-env NODE_ENV=production ./node_modules/watchify/node_modules/.bin/browserify -t vueify -e src/main.js | uglifyjs -c warnings=false -m > build/build.js
    
    events.js:85
          throw er; // Unhandled 'error' event

Looks like the executable path for `browserify` has a typo, unless I'm missing something.

Removing `/node_modules/watchify` from the beginning of the path fixes the issue.