### PR TITLE
Deprecation warning and link to vue-cli.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Browserify + Vueify example
+# Browserify + Vueify example (deprecated)
+
+Deprecated in favor of [vue-cli](https://github.com/vuejs/vue-cli) and [browserify vue-cli template](https://github.com/vuejs-templates/browserify).
 
 > Example using [vueify](https://github.com/vuejs/vueify) with Browserify.
 


### PR DESCRIPTION
Same thing as https://github.com/vuejs/vue-loader-example/pull/49